### PR TITLE
Issue 28: Introduce a startup splash screen with essential commands

### DIFF
--- a/src/streetrace/app.py
+++ b/src/streetrace/app.py
@@ -150,12 +150,24 @@ class Application:
 
     async def _run_interactive(self) -> None:
         """Handle interactive mode (conversation loop)."""
-        self.ui_bus.dispatch_ui_update(
-            ui_events.Info(
-                "Entering interactive mode. Type '/bye' to exit, '/help' for etc., "
-                "or press Ctrl+C/Ctrl+D to quit.",
-            ),
-        )
+        splash = f"""
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+                                                                 
+    🏁 Welcome to StreetRace 🚗💨                                
+                                                               
+    📚 Quick Commands:                                          
+                                                                
+    • /exit, /quit, /bye    → Exit the interactive session                   
+    • /history              → Show conversation history                       
+    • /compact              → Summarize and compact history                   
+    • /reset                → Start a new conversation                        
+    • /help, /h             → List all available commands                     
+                                                                    
+    Enjoy the ride! 🏁   
+                                                                                                            
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+            """
+        self.ui_bus.dispatch_ui_update(ui_events.Info(splash))
 
         while True:
             try:

--- a/src/streetrace/app.py
+++ b/src/streetrace/app.py
@@ -1,3 +1,4 @@
+# ruff: noqa: W293, W291
 """Orchestrate the StreetRace🚗💨 application flow and manage component interactions.
 
 This module contains the Application class which serves as the central
@@ -152,19 +153,19 @@ class Application:
         """Handle interactive mode (conversation loop)."""
         splash = f"""
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
-                                                                 
-    🏁 Welcome to StreetRace 🚗💨                                
-                                                               
-    📚 Quick Commands:                                          
-                                                                
-    • /exit, /quit, /bye    → Exit the interactive session                   
-    • /history              → Show conversation history                       
-    • /compact              → Summarize and compact history                   
-    • /reset                → Start a new conversation                        
-    • /help, /h             → List all available commands                     
-                                                                    
-    Enjoy the ride! 🏁   
-                                                                                                            
+
+    🏁 Welcome to StreetRace 🚗💨
+
+    📚 Quick Commands:
+
+    • /exit, /quit, /bye    → Exit the interactive session
+    • /history              → Show conversation history
+    • /compact              → Summarize and compact history
+    • /reset                → Start a new conversation
+    • /help, /h             → List all available commands
+
+    Enjoy the ride! 🏁
+
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
             """
         self.ui_bus.dispatch_ui_update(ui_events.Info(splash))

--- a/src/streetrace/app.py
+++ b/src/streetrace/app.py
@@ -152,11 +152,9 @@ class Application:
     async def _run_interactive(self) -> None:
         """Handle interactive mode (conversation loop)."""
         splash = f"""
-━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+🏁 Welcome to [bold]StreetRace[/bold] 🚗💨
 
-    🏁 Welcome to StreetRace 🚗💨
-
-    📚 Quick Commands:
+Quick commands:
 
     • /exit, /quit, /bye    → Exit the interactive session
     • /history              → Show conversation history
@@ -164,8 +162,9 @@ class Application:
     • /reset                → Start a new conversation
     • /help, /h             → List all available commands
 
-    Enjoy the ride! 🏁
+[dim][white]CWD: {self.args.working_dir}[/white][/dim]
 
+Enjoy the ride! 🏁
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
             """
         self.ui_bus.dispatch_ui_update(ui_events.Info(splash))

--- a/src/streetrace/ui/colors.py
+++ b/src/streetrace/ui/colors.py
@@ -29,6 +29,7 @@ class Styles:
             # Default input area
             "": "",
             "prompt": "fg:ansiwhite",
+            "placeholder": "fg:#808080",  # Dimmed gray for placeholder
             # Bottom toolbar (reverse=True, so fg/bg are inverted)
             "bottom-toolbar": "bg:ansiwhite fg:ansiblue",
             "highlight": "bg:ansibrightyellow",

--- a/src/streetrace/ui/colors.py
+++ b/src/streetrace/ui/colors.py
@@ -28,7 +28,7 @@ class Styles:
         {
             # Default input area
             "": "",
-            "prompt": "fg:ansiwhite",
+            "prompt": "fg:ansiyellow bold",
             "placeholder": "fg:#808080",  # Dimmed gray for placeholder
             # Bottom toolbar (reverse=True, so fg/bg are inverted)
             "bottom-toolbar": "bg:ansiwhite fg:ansiblue",

--- a/src/streetrace/ui/console_ui.py
+++ b/src/streetrace/ui/console_ui.py
@@ -18,7 +18,7 @@ from streetrace.ui.ui_bus import UiBus
 if TYPE_CHECKING:
     from rich.status import Status
 
-_PROMPT = "You:"
+_PROMPT = "> "
 
 _TOOLBAR_TEMPLATE = (
     "<highlight>{current_model}</highlight> | "
@@ -181,7 +181,7 @@ class ConsoleUI:
             # Defines appearance for continuation lines in multiline mode
             # Simple dots for now, could be more elaborate
             return [
-                ("class:prompt-continuation", "." * width),  # Style in Styles.PT
+                ("class:prompt-continuation", " " * width),  # Style in Styles.PT
             ]
 
         def build_bottom_toolbar() -> HTML:
@@ -205,6 +205,7 @@ class ConsoleUI:
                     prompt_continuation=build_prompt_continuation,
                     bottom_toolbar=build_bottom_toolbar,
                     validator=Validator.from_callable(send_is_typing),
+                    placeholder=[("class:placeholder", "Enter your prompt")],
                     # completer and complete_while_typing are set in __init__
                 )
         except EOFError:  # Handle Ctrl+D as a way to exit

--- a/src/streetrace/ui/ui_events.py
+++ b/src/streetrace/ui/ui_events.py
@@ -53,7 +53,7 @@ def render_markdown(obj: Markdown, console: Console) -> None:
     console.print(RichMarkdown(obj), style=Styles.RICH_INFO)
 
 
-_PROMPT = "You:"
+_PROMPT = "> "
 
 
 class UserInput(_Str):

--- a/tests/unit/ui/test_console_ui_prompt_functionality.py
+++ b/tests/unit/ui/test_console_ui_prompt_functionality.py
@@ -255,7 +255,7 @@ class TestConsoleUIPromptFunctionality:
                 # Test the continuation function
                 width = 5
                 result = prompt_continuation(width, 0, 0)
-                expected = [("class:prompt-continuation", "." * width)]
+                expected = [("class:prompt-continuation", " " * width)]
 
                 assert result == expected
 


### PR DESCRIPTION
1/ Add a splash screen intro with the list of essential commands when launching StreetRace
2/ Change prompt invitation from "You: " to "> "
3/ Add the opaque hint "Enter your prompt" for the user in the prompt invitation
4/ Change the new line continuation in prompt multiline input from "..." to spaces.
5/ Update tests