### PR TITLE
Enable global npm package installation in devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -13,12 +13,17 @@ ENV PYTHONUNBUFFERED=1 \
     POETRY_NO_INTERACTION=1 \
     POETRY_VIRTUALENVS_CREATE=true
 
-# Install system dependencies
+# Install system dependencies and GitHub CLI
 RUN apt-get update && apt-get install -y \
     git \
     curl \
     build-essential \
     bash-completion \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+    && apt-get update \
+    && apt-get install -y gh \
     && rm -rf /var/lib/apt/lists/*
 
 # Install Node.js (required for MCP tools)
@@ -41,6 +46,11 @@ RUN useradd --create-home --shell /bin/bash --user-group --uid 1000 devuser \
 
 # Switch to non-root user
 USER devuser
+
+# Configure npm for non-root user
+RUN mkdir -p /home/devuser/.npm-global \
+    && npm config set prefix '/home/devuser/.npm-global' \
+    && echo 'export PATH=/home/devuser/.npm-global/bin:$PATH' >> /home/devuser/.bashrc
 
 # Set default command
 CMD ["/bin/bash"]


### PR DESCRIPTION
## Summary
- Configure npm for non-root user to support global package installation
- Set npm prefix to `/home/devuser/.npm-global` 
- Add global bin directory to PATH in `.bashrc`
- Include GitHub CLI installation for development workflow

## Test plan
- [ ] Build the devcontainer
- [ ] Run `npm install -g <package>` to verify global installation works
- [ ] Verify global binaries are accessible in PATH
- [ ] Test GitHub CLI functionality

Fixes #44